### PR TITLE
upgrade plugin to work with pelican 3.6.0

### DIFF
--- a/embed_tweet.py
+++ b/embed_tweet.py
@@ -23,14 +23,14 @@ from pelican import signals
 import re
 
 
-def embed_tweet(sender, instance):
-    instance._content = re.sub(
+def embed_tweet(content):
+    content._content = re.sub(
         r'(^|[^@\w])@(\w{1,15})\b',
         '\\1<a href="https://twitter.com/\\2">@\\2</a>',
         re.sub(
             r'(^|[^@\w])@(\w{1,15})/status/(\d+)\b',
             '\\1<blockquote class="twitter-tweet" align="center"><a href="https://twitter.com/\\2/status/\\3">Tweet of \\2/\\3</a></blockquote>',
-            instance._content
+            content._content
         )
     ) + '<script src="//platform.twitter.com/widgets.js" charset="utf-8"></script>'
 


### PR DESCRIPTION
Hi, 
I upgraded the api to work with the current pelican version. There's now only one argument and no longer a sender and instance argument. 
