### PR TITLE
Change t@ prefix to t# to work with RST files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ How to use this?
 Conversion
 ----------
 
- 1. `t@username` will be replaced by `https://twitter.com/username`
- 1. `t@username/status/tweetid` will be replaced by `Embedded-tweet`
+ 1. `t#username` will be replaced by `https://twitter.com/username`
+ 1. `t#username/status/tweetid` will be replaced by `Embedded-tweet`
     - See: <https://dev.twitter.com/docs/embedded-tweets>
     - Example: <http://lqez.github.io/blog/gittipcom-and-forkorea.html>
 

--- a/embed_tweet.py
+++ b/embed_tweet.py
@@ -7,11 +7,11 @@ And also provides a link for Twitter username.
 
     i.e.
 
-        t@username
+        t#username
 
         will be replaced by a link to Twitter username page.
 
-        t@username/status/tweetid
+        t#username/status/tweetid
 
         will be replaced by a `Embedded-tweet`_ API.
 
@@ -31,7 +31,7 @@ def embed_tweet(instance):
         r'(^|[^/])(t)@(\w{1,15})(\b[^\/])',
         '\\1<a href="https://twitter.com/\\3">@\\3</a>\\4',
         re.sub(
-            r'(^|[^/])(t)@(\w{1,15})/status/(\d+)\b',
+            r'(^|[^/])(t)#(\w{1,15})/status/(\d+)\b',
             '\\1<blockquote class="twitter-tweet" align="center"><a href="https://twitter.com/\\3/status/\\4">Tweet of \\3/\\4</a></blockquote>',
             instance._content
         )

--- a/embed_tweet.py
+++ b/embed_tweet.py
@@ -29,7 +29,7 @@ def embed_tweet(instance):
         return
 
     instance._content = re.sub(
-        r'(^|[^/])(t)@(\w{1,15})(\b[^\/])',
+        r'(^|[^/])(t)#(\w{1,15})(\b[^\/])',
         '\\1<a href="https://twitter.com/\\3">@\\3</a>\\4',
         re.sub(
             r'(^|[^/])(t)#(\w{1,15})/status/(\d+)\b',

--- a/embed_tweet.py
+++ b/embed_tweet.py
@@ -19,8 +19,9 @@ And also provides a link for Twitter username.
 
 """
 
-from pelican import signals
 import re
+
+from pelican import signals
 
 
 def embed_tweet(instance):


### PR DESCRIPTION
Resolves: #5 

* Change embed-tweet prefix to t# to work with RST files
* Sort import order according to PEP8
* Update README with the new prefix

Example product: 
* Input rst: https://github.com/ikding/website/blob/master/content/climate_tech/2020-03-21_how_led_works.rst
* Output html: https://ikding.github.io/how-led-works.html


Please review when you have a chance! @lqez 